### PR TITLE
Fix: Remove NOINDEX,NOFOLLOW tags and update robots.txt

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/about/index.html
+++ b/about/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/achievements/index.html
+++ b/achievements/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/categories/index.html
+++ b/categories/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/certifications/index.html
+++ b/certifications/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/contact/index.html
+++ b/contact/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/index.html
+++ b/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/index.html
+++ b/post/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/page/2/index.html
+++ b/post/page/2/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/page/3/index.html
+++ b/post/page/3/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/project-1/index.html
+++ b/post/project-1/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/project-2/index.html
+++ b/post/project-2/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/project-3/index.html
+++ b/post/project-3/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/project-4/index.html
+++ b/post/project-4/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/project-5/index.html
+++ b/post/project-5/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/project-6/index.html
+++ b/post/project-6/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/post/project-7/index.html
+++ b/post/project-7/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/publications/index.html
+++ b/publications/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,2 @@
 User-agent: *
-# robotstxt.org - if ENV production variable is false robots will be disallowed.
-
-  Disallow: /
 

--- a/tags/index.html
+++ b/tags/index.html
@@ -10,8 +10,6 @@
     <meta name="generator" content="Hugo 0.81.0" />
     
     
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-    
 
     
 


### PR DESCRIPTION
I removed the <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW"> tag from all main HTML pages to allow search engine indexing and following links.

I also updated robots.txt by removing 'Disallow: /' to permit crawlers access to the site.

These changes address the critical issue of your site being hidden from search engines. Paginated pages with a simple 'noindex' tag were left as is, which is a common practice.